### PR TITLE
Avoid file locking in concurrent access

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -81,7 +81,7 @@ int main()
 
   FILE* shim_file;
 
-  if ((shim_file = _wfsopen(filename, L"r,ccs=UTF-8", _SH_DENYNO)) == NULL ) {
+  if ((shim_file = _wfsopen(filename, L"r,ccs=UTF-8", _SH_DENYNO)) == NULL) {
     fprintf(stderr, "Cannot open shim file for read.\n");
 
     return 1;

--- a/shim.c
+++ b/shim.c
@@ -81,7 +81,7 @@ int main()
 
   FILE* shim_file;
 
-  if (_wfopen_s(&shim_file, filename, L"r,ccs=UTF-8")) {
+  if ((shim_file = _wfsopen(filename, L"r,ccs=UTF-8", _SH_DENYNO)) == NULL ) {
     fprintf(stderr, "Cannot open shim file for read.\n");
 
     return 1;


### PR DESCRIPTION
It appears that _wfopen_s could be the reason for a bug in:
  https://gitlab.haskell.org/haskell/ghcup-hs/-/issues/154

where these shim binaries are called concurrently. An already running
process may lock the shim file during the short parsing period and cause
the other process to fail.

_wfsopen with _SH_DENYNO should allow other processes to acces the
shimgen just fine.