### PR TITLE
Fix out of bounds errors

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -88,7 +88,7 @@ int main()
 
   FILE* shim_file;
 
-  if ((shim_file = _wfsopen(filename, L"r,ccs=UTF-8", _SH_DENYNO)) == NULL ) {
+  if ((shim_file = _wfsopen(filename, L"r,ccs=UTF-8", _SH_DENYNO)) == NULL) {
     fprintf(stderr, "Cannot open shim file for read.\n");
 
     exit_code = 1;

--- a/shim.c
+++ b/shim.c
@@ -112,9 +112,8 @@ int main()
 
     if (line[0] == L'p' && line[1] == L'a' && line[2] == L't' && line[3] == L'h') {
       // Reading path
-      path = calloc(len, sizeof(wchar_t));
+      path = calloc(len + 1, sizeof(wchar_t));
       wmemcpy(path, line + 7, len);
-      path[len] = 0;
 
       command_length += len;
       path_length = len;
@@ -124,9 +123,8 @@ int main()
 
     if (line[0] == L'a' && line[1] == L'r' && line[2] == L'g' && line[3] == L's') {
       // Reading args
-      args = calloc(len, sizeof(wchar_t));
+      args = calloc(len + 1, sizeof(wchar_t));
       wmemcpy(args, line + 7, len);
-      args[len] = 0;
 
       command_length += len + 1;
       args_length = len;


### PR DESCRIPTION
It seems the idea here was to have NUL terminated strings?

At any rate, this is an out of bounds error and calloc will
take care of zeroing the memory anyway. We increment it by
1 element to make sure the string always ends with NUL.

Error log:

```
Dr. Memory version 2.3.0 build 1 built on Feb  6 2020 06:09:03
Windows version: WinVer=105;Rel=2009;Build=19042;Edition=Enterprise
Dr. Memory results for pid 5456: "shim.exe"
Application cmdline: "C:\Users\hasuf\scoop-better-shimexe\shim.exe"
Recorded 118 suppression(s) from default C:\Program Files (x86)\Dr. Memory\bin\suppress-default.txt

Error #1: UNADDRESSABLE ACCESS beyond heap bounds: writing 0x02d085fc-0x02d085fe 2 byte(s)
# 0 main               [C:\Users\hasuf\scoop-better-shimexe\shim.c:117]
Note: @0:00:00.766 in thread 8832
Note: refers to 0 byte(s) beyond last valid byte in prior malloc
Note: prev lower malloc:  0x02d085c0-0x02d085fc
Note: instruction: data16 mov    %ax -> (%edx,%ecx,2)

Error #2: UNADDRESSABLE ACCESS beyond heap bounds: writing 0x02d08e62-0x02d08e64 2 byte(s)
# 0 main               [C:\Users\hasuf\scoop-better-shimexe\shim.c:129]
Note: @0:00:00.783 in thread 8832
Note: refers to 0 byte(s) beyond last valid byte in prior malloc
Note: prev lower malloc:  0x02d08e40-0x02d08e62
Note: instruction: data16 mov    %dx -> (%ecx,%eax,2)

===========================================================================
FINAL SUMMARY:

DUPLICATE ERROR COUNTS:

SUPPRESSIONS USED:

ERRORS FOUND:
      2 unique,     2 total unaddressable access(es)
      0 unique,     0 total uninitialized access(es)
      0 unique,     0 total invalid heap argument(s)
      0 unique,     0 total GDI usage error(s)
      0 unique,     0 total handle leak(s)
      0 unique,     0 total warning(s)
      0 unique,     0 total,      0 byte(s) of leak(s)
      0 unique,     0 total,      0 byte(s) of possible leak(s)
ERRORS IGNORED:
      5 potential error(s) (suspected false positives)
         (details: C:\Users\hasuf\AppData\Roaming\Dr. Memory\DrMemory-shim.exe.5456.000\potential_errors.txt)
      1 potential leak(s) (suspected false positives)
         (details: C:\Users\hasuf\AppData\Roaming\Dr. Memory\DrMemory-shim.exe.5456.000\potential_errors.txt)
     31 unique,    80 total,  13957 byte(s) of still-reachable allocation(s)
         (re-run with "-show_reachable" for details)
Details: C:\Users\hasuf\AppData\Roaming\Dr. Memory\DrMemory-shim.exe.5456.000\results.txt
```