### PR TITLE
Include "Shim" in "Could not create process with command" error

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -243,7 +243,7 @@ int main()
 
       pi.hProcess = sei.hProcess;
     } else {
-      fprintf(stderr, "Could not create process with command '%ls'.\n", cmd);
+      fprintf(stderr, "Shim: Could not create process with command '%ls'.\n", cmd);
 
       exit_code = 1;
       goto cleanup;


### PR DESCRIPTION
I've sometimes fiddled with scripts and shims for shortcuts and I really would've appreciated having this error tell me it's the shim telling me that I'm dumb and set up my path wrong, I hope this helps other fiddlers like me in the future